### PR TITLE
Add Instify image generator module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ These endpoints return objects of the form:
 ```
 
 Other record actions like `POST /api/record` and `PUT /api/record/:id` remain unchanged.
+
+## Instify Image Generator
+
+The `/instify` page demonstrates generating certificates and invites from JSON templates.
+It uses Fabric.js and PapaParse (both installed via NPM) to merge CSV data into a canvas
+and export the result as a PNG.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "socket.io-client": "^4.8.1",
     "vite": "^6.3.5",
     "vite-plugin-pwa": "^1.0.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "fabric": "^5.2.4",
+    "papaparse": "^5.4.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",

--- a/public/templates/sample.json
+++ b/public/templates/sample.json
@@ -1,0 +1,47 @@
+{
+  "version": "5.2.4",
+  "objects": [
+    {
+      "type": "rect",
+      "left": 0,
+      "top": 0,
+      "width": 800,
+      "height": 600,
+      "fill": "#ffffff",
+      "stroke": "#aaaaaa",
+      "strokeWidth": 2
+    },
+    {
+      "type": "textbox",
+      "name": "title",
+      "text": "Certificate of Completion",
+      "left": 400,
+      "top": 100,
+      "fontSize": 32,
+      "fontWeight": "bold",
+      "textAlign": "center",
+      "originX": "center"
+    },
+    {
+      "type": "textbox",
+      "name": "name",
+      "text": "{name}",
+      "left": 400,
+      "top": 250,
+      "fontSize": 28,
+      "textAlign": "center",
+      "originX": "center"
+    },
+    {
+      "type": "textbox",
+      "name": "course",
+      "text": "{course}",
+      "left": 400,
+      "top": 320,
+      "fontSize": 24,
+      "fill": "#555555",
+      "textAlign": "center",
+      "originX": "center"
+    }
+  ]
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,10 +31,11 @@ import AllLeadByAdmission from './Reports/allLeadByAdmission';
 import AddAttendance from './pages/AddAttendance';
 import AllAttendance from './Reports/allAttendance';
 import AllBatches from './Reports/allBatches';
-import AllBalance from './Reports/allBalance'; // <-- ✅ NEW PAGE
+import AllBalance from './Reports/allBalance';
 import AddAccount from './pages/AddAccount';
 import AllExams from './Reports/allExams';
 import Institutes from './pages/Institutes';
+import Instify from './pages/Instify';
 
 export default function App() {
   return (
@@ -73,9 +74,10 @@ export default function App() {
         <Route path="followup" element={<Followup />} />
         <Route path="addAttendance" element={<AddAttendance />} />
         <Route path="allAttendance" element={<AllAttendance />} />
-        <Route path="allBalance" element={<AllBalance />} /> {/* ✅ Added Route */}
-        <Route path="allBatches" element={<AllBatches />} /> {/* ✅ Added Route */}
+        <Route path="allBalance" element={<AllBalance />} />
+        <Route path="allBatches" element={<AllBatches />} />
         <Route path="whatsapp" element={<WhatsAppAdminPage />} />
+        <Route path="instify" element={<Instify />} />
          <Route path="allExams" element={<AllExams />} />
       </Route>
 

--- a/src/pages/Instify.jsx
+++ b/src/pages/Instify.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { fabric } from 'fabric';
+import Papa from 'papaparse';
+
+const Instify = () => {
+  const canvasRef = useRef(null);
+  const [canvas, setCanvas] = useState(null);
+  const [csv, setCsv] = useState('');
+
+  useEffect(() => {
+    const c = new fabric.Canvas(canvasRef.current, { width: 800, height: 600 });
+    setCanvas(c);
+
+    fetch('/templates/sample.json')
+      .then(res => res.json())
+      .then(data => {
+        c.loadFromJSON(data, c.renderAll.bind(c));
+      })
+      .catch(() => {});
+
+    return () => c.dispose();
+  }, []);
+
+  const handleTemplateUpload = async (e) => {
+    if (!canvas) return;
+    const file = e.target.files[0];
+    if (!file) return;
+    const text = await file.text();
+    const json = JSON.parse(text);
+    canvas.loadFromJSON(json, canvas.renderAll.bind(canvas));
+  };
+
+  const mergeData = () => {
+    if (!canvas || !csv) return;
+    const parsed = Papa.parse(csv, { header: true }).data[0];
+    if (!parsed) return;
+    canvas.getObjects().forEach(obj => {
+      if (obj.name && parsed[obj.name]) {
+        obj.text = parsed[obj.name];
+      }
+    });
+    canvas.renderAll();
+  };
+
+  const download = () => {
+    if (!canvas) return;
+    const url = canvas.toDataURL({ format: 'png' });
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'instify.png';
+    link.click();
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Instify Image Generator</h1>
+
+      <div className="flex flex-col gap-2 max-w-xl">
+        <input type="file" accept="application/json" onChange={handleTemplateUpload} />
+        <textarea
+          className="border p-2 h-24"
+          placeholder="Paste CSV data here (header: name,course)"
+          value={csv}
+          onChange={(e) => setCsv(e.target.value)}
+        />
+        <div className="flex gap-2">
+          <button onClick={mergeData} className="bg-blue-600 text-white px-3 py-1 rounded">Merge Data</button>
+          <button onClick={download} className="bg-green-600 text-white px-3 py-1 rounded">Download PNG</button>
+        </div>
+      </div>
+
+      <canvas ref={canvasRef} className="border w-full mt-4" />
+    </div>
+  );
+};
+
+export default Instify;


### PR DESCRIPTION
## Summary
- add a sample Fabric template
- create Instify page to merge JSON templates with CSV data
- expose new route and load Fabric.js + PapaParse via CDN
- document Instify tool in README
- refine Instify module to use npm packages instead of CDN
- clean comments from routes

## Testing
- `npm run build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6873e7fe3d248322822a053e3f129eca